### PR TITLE
Change author.img in docked.coffee

### DIFF
--- a/docpad.coffee
+++ b/docpad.coffee
@@ -32,7 +32,7 @@ docpadConfig = {
       ]
     author:
       name: 'John U. Doe'
-      image: ''
+      img: ''
       url: '/'
       location: 'Nowhere, IL',
       bio: 'I do stuff and things'


### PR DESCRIPTION
The attribute author.image needs to be changed to author.img, the code in the payouts and partials are looking for author.img in order to display the image